### PR TITLE
Fix: removed check as it will be caught in the catch clause

### DIFF
--- a/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/netengine/FileTransfer.java
+++ b/robocode.roborumble/src/main/java/net/sf/robocode/roborumble/netengine/FileTransfer.java
@@ -119,9 +119,6 @@ public class FileTransfer {
 		try {
 			// Create connection
 			conn = connectToHttpInputConnection(new URL(url));
-			if (conn == null) {
-				throw new IOException("Could not open connection to: " + url);
-			}
 
 			// Begin the download
 			final DownloadThread downloadThread = new DownloadThread(conn, filename);


### PR DESCRIPTION
Fix the identified security issue Spotbugs tool
---
Issue:
---
Redundant nullcheck of value known to be non-null
This method contains a redundant check of a known non-null value against the constant null.

Solution:
----
Investigated the reported code for a fix, it is evident that the same exception is caught in catch clause of the code.
Hence, the best practice is to remove the code which is redundant.