### PR TITLE
Fix rilling#90: software vulnerability in 737 AutoExtrac.java

### DIFF
--- a/robocode.installer/src/main/java/net/sf/robocode/installer/AutoExtract.java
+++ b/robocode.installer/src/main/java/net/sf/robocode/installer/AutoExtract.java
@@ -734,25 +734,29 @@ public class AutoExtract implements ActionListener {
     private static boolean deleteFileAndParentDirsIfEmpty(File file) {
         boolean wasDeleted = false;
 
-        if (file != null && file.exists()) {
-            if (file.isDirectory()) {
-                wasDeleted = deleteDir(file);
-            } else {
-                wasDeleted = file.delete();
+        try {
+            if (file != null && file.getCanonicalPath().equals(file.getAbsolutePath())) {
+                if (file.isDirectory()) {
+                    wasDeleted = deleteDir(file);
+                } else {
+                    wasDeleted = file.delete();
 
-                File parent = file;
+                    File parent = file;
 
-                while (wasDeleted && (parent = parent.getParentFile()) != null) {
-                    // Delete parent directory, but only if it is empty
-                    File[] files = parent.listFiles();
+                    while (wasDeleted && (parent = parent.getParentFile()) != null) {
+                        // Delete parent directory, but only if it is empty
+                        File[] files = parent.listFiles();
 
-                    if (files != null && files.length == 0) {
-                        wasDeleted = deleteDir(parent);
-                    } else {
-                        wasDeleted = false;
+                        if (files != null && files.length == 0) {
+                            wasDeleted = deleteDir(parent);
+                        } else {
+                            wasDeleted = false;
+                        }
                     }
                 }
             }
+        } catch (IOException e) {
+            System.err.println("Error validating file path: " + e.getMessage());
         }
         return wasDeleted;
     }


### PR DESCRIPTION
## Description
The type of this software vulnerability is Path Traversal. This vulnerability happens when the application accepts file paths without strict validation, allowing attackers to manipulate paths using techniques to access or delete files out of the intended range of directory. It exploits the lack of checks on whether the path is safe or valid.
Unsanitized input from a command line argument flows into exists, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to bypass the logic of the application in the conditional expression.

## Changes
- In order to deal with this issue, `file.exists()` could be replaced by `file.getCanonicalPath()` method, which could eliminate any symbolic links or relative path components. 
- After that, compare getCanonicalPath() with getAbsolutePath() to ensure the inputted path is not attempting traversal out of the expected directory.
- Through this improvement of validation, the file operations could be proceeded safely, and the method woulc skip the related operation if something goes wrong.
