### PR TITLE
Fix 108: Software Vulnerability in 251 Battle.java

### DIFF
--- a/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
+++ b/robocode.battle/src/main/java/net/sf/robocode/battle/Battle.java
@@ -248,7 +248,7 @@ public final class Battle extends BaseBattle {
 		parallelOn = System.getProperty("PARALLEL", "false").equals("true");
 		if (parallelOn) {
 			// how could robots share CPUs ?
-			double parallelConstant = robots.size() / Runtime.getRuntime().availableProcessors();
+			double parallelConstant = (double) robots.size() / Runtime.getRuntime().availableProcessors();
 
 			// four CPUs can't run two single threaded robot faster than two CPUs
 			if (parallelConstant < 1) {


### PR DESCRIPTION
## Issue
Integral division result cast to double or float
This code casts the result of an integral division (e.g., int or long division) operation to double or float.

## Solution
Cast one operand to `double` before performing the division to ensure accurate floating-point computation.